### PR TITLE
FIX for issues with ActiveRecord 3.1+

### DIFF
--- a/lib/auditor/audit.rb
+++ b/lib/auditor/audit.rb
@@ -12,10 +12,16 @@ class Audit < ActiveRecord::Base
   serialize :audited_changes
 
   default_scope order(:version, :created_at)
-  scope :modifying, lambda { where('audited_changes is not null') }
+  scope :modifying, lambda {
+    where( [
+      'audited_changes is not ? and audited_changes is not ?',
+      nil,        # ActiveRecord 3.0
+      nil.to_yaml # ActiveRecord 3.1
+    ] )
+  }
   scope :trail, lambda { |audit|
     where('auditable_id = ? and auditable_type = ? and version <= ?',
-    audit.auditable_id, audit.auditable_type, audit.version) 
+    audit.auditable_id, audit.auditable_type, audit.version)
   }
 
   def attribute_snapshot


### PR DESCRIPTION
When using AR 3.0, empty serialized fields (like `Audit#audited_changes`) were either not written to the DB or not serialized before writing.  In effect, an empty serialized field was stored as `NULL`.  `nil` in the model was `NULL` in the DB.

In AR 3.1, that changed; the field is apparently serialized no matter what, resulting in a YAML string representing a `nil`.  Nonetheless, it's a string and not `NULL`.  Thus, the explicit check in the `Audit.modifying` scope failed.

I've just fixed the scope definition (took me a while to find that bug…) and left the rest untouched, even though I've tested the changes with both AR 3.1.3 and AR 3.2.1.  It'd be nice if you could take a look, merge if okay and adjust the gemspec to allow for `activerecord >3.0.0` soon.  :)

Cheers,
Carlo.
