### PR TITLE
Making the default_scope call compatible with Rails 4

### DIFF
--- a/lib/auditor/audit.rb
+++ b/lib/auditor/audit.rb
@@ -11,7 +11,7 @@ class Audit < ActiveRecord::Base
 
   serialize :audited_changes
 
-  default_scope order(:version, :created_at)
+  default_scope lambda { order(:version, :created_at) }
   scope :modifying, lambda {
     where( [
       'audited_changes is not ? and audited_changes not like ?',


### PR DESCRIPTION
Calling #default_scope without a block is deprecated in Rails 4.0 and totally
removed in Rails 4.1.

This pull request fix the issue so 'rake spec' runs again with Rails 4.
